### PR TITLE
Fix validation issue with JSON template

### DIFF
--- a/Scripts/CreateAzureServicesScriptResources.json
+++ b/Scripts/CreateAzureServicesScriptResources.json
@@ -52,7 +52,7 @@
       "type": "string",
       "allowedValues": [
         "12.0",
-        "2.0",
+        "2.0"
       ],
       "metadata": {
         "description": "The version of the database server."


### PR DESCRIPTION
There was a trailing comma that was causing validation to fail on JSON template in sqlServerVersion parameter.