### PR TITLE
Moved sql instance types to variables

### DIFF
--- a/Scripts/CreateAzureServicesScript.ps1
+++ b/Scripts/CreateAzureServicesScript.ps1
@@ -85,7 +85,8 @@ $ResourceParameters = @{
     sqlDatabaseName = $SqlDatabaseName;
     sqlCollation = "SQL_Latin1_General_CP1_CI_AS";
     sqlEdition = $sqlEdition;
-    sqlRequestedServiceObjectiveName = $sqlRequestedServiceObjectiveName;
+    sqlMaxSizeBytes = "1073741824";
+	sqlRequestedServiceObjectiveName = $sqlRequestedServiceObjectiveName;
 
     # website parameters
     web1SiteName = $Web1SiteName;

--- a/Scripts/CreateAzureServicesScript.ps1
+++ b/Scripts/CreateAzureServicesScript.ps1
@@ -35,12 +35,15 @@ $StorageAccountType = "Standard_LRS"
 $StorageAccountLocation = $ResourceGroupLocation
 
 # AzureSQL Server parameters
+# This will create ann AzureSQL Standard S0 instance please review https://azure.microsoft.com/pricing/details/sql-database/ for price details
 $SqlServerName = ("auisqlsr" + $suffix)
 $SqlServerLocation = $ResourceGroupLocation
 $SQLServerVersion = "2.0"
 $SqlAdministratorLogin = "mksa"
 $SqlAdministratorLoginPassword = "Password.1%"
 $SqlDatabaseName = ("auisqldb" + $suffix)
+$sqlEdition = "Standard"
+$sqlRequestedServiceObjectiveName = "S0";
 
 # WebSite parameters
 $Web1SiteName = ("auiregistration" + $suffix)
@@ -81,9 +84,8 @@ $ResourceParameters = @{
     sqlAdministratorLoginPassword = $SqlAdministratorLoginPassword;
     sqlDatabaseName = $SqlDatabaseName;
     sqlCollation = "SQL_Latin1_General_CP1_CI_AS";
-    sqlEdition = "Standard"
-    sqlMaxSizeBytes = "1073741824";
-    sqlRequestedServiceObjectiveName = "S0";
+    sqlEdition = $sqlEdition;
+    sqlRequestedServiceObjectiveName = $sqlRequestedServiceObjectiveName;
 
     # website parameters
     web1SiteName = $Web1SiteName;

--- a/Scripts/CreateAzureServicesScript.ps1
+++ b/Scripts/CreateAzureServicesScript.ps1
@@ -35,7 +35,7 @@ $StorageAccountType = "Standard_LRS"
 $StorageAccountLocation = $ResourceGroupLocation
 
 # AzureSQL Server parameters
-# This will create ann AzureSQL Standard S0 instance please review https://azure.microsoft.com/pricing/details/sql-database/ for price details
+# This will create an AzureSQL Standard S0 instance please review https://azure.microsoft.com/pricing/details/sql-database/ for price details
 $SqlServerName = ("auisqlsr" + $suffix)
 $SqlServerLocation = $ResourceGroupLocation
 $SQLServerVersion = "2.0"


### PR DESCRIPTION
As per this issue https://github.com/Microsoft/AzureUsageAndBillingPortal/issues/12

I have created two variables called $sqlEdition and $sqlRequestedServiceObjectiveName and used these in the $ResourceParameters to control what plan is used when setting the SQL instance up.