### PR TITLE
Improve the Error Handling for RateCardRestApiCall in WebJobBillingData

### DIFF
--- a/Commons/AzureResourceManagerUtil.cs
+++ b/Commons/AzureResourceManagerUtil.cs
@@ -36,6 +36,7 @@ using System.Web.Helpers;
 using System.Net;
 using System.Web;
 using System.Text;
+using System.IO;
 
 namespace Commons
 {
@@ -736,6 +737,17 @@ namespace Commons
 
                 response = (HttpWebResponse)request.GetResponse();
             }
+            catch (WebException webExc)
+            {
+                Stream str = webExc.Response.GetResponseStream();
+                using (StreamReader readStream = new StreamReader(str, Encoding.UTF8))
+                {
+                    string content = readStream.ReadToEnd();
+                    Console.WriteLine("Exception: RateCardRestApiCall->e.message: " + webExc.Message);
+                    Console.WriteLine("Response content: " + content);
+                }
+                response = null;
+            }
             catch (Exception e)
             {
                 // Exception occurs because of:
@@ -743,7 +755,7 @@ namespace Commons
                 //      "The remote server returned an error: (403) Forbidden."
                 //      "The remote server returned an error: (400) Bad Request."
                 //      "The remote server returned an error: (404) Not Found."
-                Console.WriteLine("Exception: RateCardRestApiCall1-e.message: {0}", e.Message);
+                Console.WriteLine("Exception: RateCardRestApiCall->e.message: {0}", e.Message);
                 response = null;
             }
 

--- a/WebJobBillingData/Functions.cs
+++ b/WebJobBillingData/Functions.cs
@@ -293,7 +293,15 @@ namespace WebJobBillingData
                         ConfigurationManager.AppSettings["ida:RegionInfo"].ToString());
                     Console.WriteLine("Request cost info from RateCard service.");
                     RateCardPayload rateCardInfo = GetRateCardInfo(rateCardURL, br.OrganizationId);
-                    Console.WriteLine("Received cost info: " + rateCardInfo.ToString());
+                    if (rateCardInfo == null)
+                    {
+                        Console.WriteLine("Problem receiving cost info occured - see log for details.");
+                        continue;
+                    }
+                    else
+                    {
+                        Console.WriteLine("Received cost info: " + rateCardInfo.ToString());
+                    }
 
                     // if granularity=hourly then report up to prev. hour,
                     // if granularity=daily then report up to prev. day. Othervise will get 400 error


### PR DESCRIPTION
Improve the Error Handling for RateCardRestApiCall in WebJobBillingData
That will fix:
- https://github.com/Microsoft/AzureUsageAndBillingPortal/issues/15 -  WebJobBillingData.Functions.ProcessQueueMessage() method code defect
- https://github.com/Microsoft/AzureUsageAndBillingPortal/issues/14 -  AzureResourceManagerUtil.RateCardRestApiCall() better error handling

