### PR TITLE
fixing creating azure resource powershell parameter name not same with template

### DIFF
--- a/Scripts/CreateAzureServicesScript.ps1
+++ b/Scripts/CreateAzureServicesScript.ps1
@@ -96,8 +96,8 @@ $ResourceParameters = @{
 	sqlRequestedServiceObjectiveName = $sqlRequestedServiceObjectiveName;
 
     # website parameters
-    web1SiteName = $Web1SiteName;
-    web2SiteName = $Web2SiteName;
+    registrationWebSiteName = $Web1SiteName;
+    dashboardWebSiteName = $Web2SiteName;
     webHostingPlanName = $WebHostingPlanName;
     webSiteLocation = $WebSiteLocation;
     webSiteInsightsLocation = $webSiteInsightsLocation;


### PR DESCRIPTION
When I try to use powershell to deploy 

I found powershell will asking for registrationWebSiteName and dashboardWebSiteName again

then fail to deploy

following picture showing error details
![error](https://cloud.githubusercontent.com/assets/891383/22508946/0b7cc786-e8c7-11e6-9977-71360f78c777.png)

---
I found out that creating azure resource powershell parameter: websitename not match with arm template 

this request fixing this mirror error